### PR TITLE
Fix importlib_metadata pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: ded03f9c5d41c193dfe5869634d78211
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >=3.5
     # This is listed upstream in extras_require but is, in fact, required
-    - importlib_metadata >=0.23,<4
+    - importlib_metadata >=0.23,<5
 
 test:
   requires:


### PR DESCRIPTION
I think the upper version is supposed to be 5. See:
    https://github.com/kislyuk/argcomplete/blob/develop/setup.py#L8

I'm experiencing some weirdness downstream in conda-forge/dvc-feedstock/pull/213 and I suspect this could be related.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
